### PR TITLE
管理者情報登録後、管理者ログイン画面にリダイレクトするよう修正

### DIFF
--- a/src/main/java/jp/co/sample/emp_management/controller/AdministratorController.java
+++ b/src/main/java/jp/co/sample/emp_management/controller/AdministratorController.java
@@ -75,7 +75,7 @@ public class AdministratorController {
 		// フォームからドメインにプロパティ値をコピー
 		BeanUtils.copyProperties(form, administrator);
 		administratorService.insert(administrator);
-		return "employee/list";
+		return "redirect:/";
 	}
 
 	/////////////////////////////////////////////////////


### PR DESCRIPTION
管理者情報登録後、管理者ログイン画面に遷移するようにしました。
ダブルサブミット対策で、画面遷移をリダイレクトにするよう修正しました。

お手数をお掛け致しますが、ご確認の上、
コメント、承認、取り下げのいずれかをいただきますようお願い致します。