### PR TITLE
課題4-2 価格フォーマット

### DIFF
--- a/src/main/resources/templates/employee/detail.html
+++ b/src/main/resources/templates/employee/detail.html
@@ -168,7 +168,7 @@
                   <tr>
                     <th nowrap>給料</th>
                     <td>
-                      <span th:utext="${employee.salary + '円'}">400000円</span>
+                      <span th:text="${#numbers.formatInteger(employee.salary, 2, 'COMMA')}">400000円</span>
                     </td>
                   </tr>
                   <tr>


### PR DESCRIPTION
従業員詳細画面の「給与」表示のところを　「100,000」のように千単位で「,」が入るように修正しました。

ご確認の上、プルリクエストをお願いいたします。